### PR TITLE
Rewrite XML to PHP array conversion

### DIFF
--- a/Classes/Utility/ConnectorUtility.php
+++ b/Classes/Utility/ConnectorUtility.php
@@ -71,31 +71,27 @@ class ConnectorUtility
      * On the other hand the reverse conversion is fine with t3lib_div::array2xml_cs().
      *
      * @param string $string XML to parse
+     * @param int $options LIBXML options for XML parsing (optional)
      * @throws \Exception
      * @return array PHP array
      */
-    static public function convertXmlToArray($string)
+    static public function convertXmlToArray($string, $options = null)
     {
-        $phpArray = array();
         // If input string is empty, exit with exception
         if (empty($string)) {
             throw new \Exception('XML string is empty!', 1294325109);
         }
 
         // Try loading the string into the Simple XML library
-        $xmlObject = simplexml_load_string($string);
+        $xmlObject = simplexml_load_string($string, null, $options);
+        
         // If the value returned is false, the XML could not be parsed
         if ($xmlObject === false) {
             throw new \Exception('XML string is invalid!', 1294325195);
         }
-
+        
         // Transform XML into a PHP array
-        foreach ($xmlObject as $key => $value) {
-            if (!isset($phpArray[$key])) {
-                $phpArray[$key] = array();
-            }
-            $phpArray[$key][] = self::handleXmlNode($value);
-        }
+        $phpArray = self::handleXmlNode($xmlObject, array_keys($xmlObject->getDocNamespaces()));
 
         return $phpArray;
     }
@@ -105,33 +101,98 @@ class ConnectorUtility
      * the attribute and children information. Calls itself recursively on child nodes.
      *
      * @param \SimpleXMLElement $node XML node to transform
+     * @param array $namespaces List of namespaces used (optional)
      * @return array Transformed XML node and children
      */
-    static public function handleXmlNode(\SimpleXMLElement $node)
+    static public function handleXmlNode(\SimpleXMLElement $node, $namespaces = [])
     {
-        // Initializations
-        $nodeArray = array();
-        $nodeArray['value'] = trim((string)$node);
-        $nodeArray['children'] = array();
-        $nodeArray['attributes'] = array();
-        // Loop on all children, if any
-        $children = $node->children();
-        if ($children->count() > 0) {
-            // If there are child nodes, recursively transform them into arrays too
-            foreach ($children as $key => $subNode) {
-                if (!isset($nodeArray[$key])) {
-                    $nodeArray[$key] = array();
-                }
-                $nodeArray['children'][$key][] = self::handleXmlNode($subNode);
+        // Init
+        $nodeArray = [];
+        
+        // Set value if there is any
+        if (strlen($value = trim((string)$node))) {
+            $nodeArray["value"] = $value;
+        }
+        
+        // Fill attributes
+        $attributes = self::handleAttributes($node);
+        foreach ($namespaces as $namespace) {
+            if (strlen($namespace)) {
+                $attributes = array_merge($attributes, self::handleAttributes($node, $namespace));
             }
         }
-        // Handle attributes, if any
-        $attributes = $node->attributes();
-        if ($attributes->count() > 0) {
-            foreach ($attributes as $key => $value) {
-                $nodeArray['attributes'][$key] = (string)$value;
+        // only add attributes if there are any
+        if (count($attributes)) {
+            $nodeArray["attributes"] = $attributes;
+        }
+        
+        // Fill children
+        $children = self::handleChildren($node, $namespaces);
+        foreach ($namespaces as $namespace) {
+            if (strlen($namespace)) {
+                $children = array_merge($children, self::handleChildren($node, $namespaces, $namespace));
             }
         }
+        // only add children if there are any
+        if (count($children)) {
+            $nodeArray["children"] = $children;
+        }
+        
         return $nodeArray;
+    }
+    
+    /**
+     * Go through children of a node and parse them recursively
+     * 
+     * @param \SimpleXMLElement $node
+     * @param array $namespaces List of namespaces used (optional)
+     * @param string $namespace Namespace to be parsed (optional)
+     * @return array
+     */
+    static public function handleChildren(\SimpleXMLElement $node, $namespaces = [], $namespace = null) {
+        $children = $node->children($namespace, true);
+        $array = [];
+        if ($children->count() > 0) {
+            // set base of array key in case of a namespace
+            $base = isset($namespace) ? $namespace . ":" : "";
+            // Go through all child nodes and recursively convert them to arrays
+            foreach ($children as $key => $subnode) {
+                $parsed = self::handleXmlNode(
+                        $subnode,
+                        array_unique(array_merge($namespaces, array_keys($subnode->getDocNamespaces(false, false))))
+                    );
+                // define the array key for this child
+                $keyname = $base . $key;
+                // define child array once
+                if (!isset($array[$keyname])) {
+                    $array[$keyname] = [];
+                }
+                // add new entry to the child array
+                $array[$keyname][] = $parsed;
+            }
+        }
+        return $array;
+    }
+    
+    /**
+     * Extracts all regular attributes or all attributes of a namespace
+     * 
+     * @param \SimpleXMLElement $node XML node
+     * @param string $namespace Namespace to be used (optional)
+     * @return array All attributes of the specified namespace (if any)
+     */
+    static public function handleAttributes(\SimpleXMLElement $node, $namespace = null) {
+        // Get attributes of a namespace
+        $attributes = $node->attributes($namespace, true);
+        $parsed = [];
+        if (isset($attributes) && $attributes->count() > 0) {
+            // Define base to be used for the array key
+            $base = isset($namespace) ? $namespace . ":" : "";
+            // Go through the attributes and add them to the array
+            foreach ($attributes as $attribute => $value) {
+                $parsed[$base . $attribute] = trim((string)$value);
+            }
+        }
+        return $parsed;
     }
 }


### PR DESCRIPTION
- Namespaced nodes and attributes are now also included in the conversion
- Root node now included (including its attributes)
- Fixed erroneous empty children
- LIBXML options can now be defined (optional)

As the new resulting array starts one node earlier, projects/extension relying on this functionality may need slight changes to work again. Other than that, the layout of the array remains the same.