### PR TITLE
[TASK] removes type-hint from setError function

### DIFF
--- a/Classes/Utility/FileUtility.php
+++ b/Classes/Utility/FileUtility.php
@@ -151,8 +151,8 @@ class FileUtility implements SingletonInterface
      *
      * @param string $error
      */
-    public function setError(string $error)
+    public function setError($error)
     {
-        $this->error = $error;
+        $this->error = (string) $error;
     }
 }


### PR DESCRIPTION
Hi François,
you removed some  type declarations in Classes/Utility/FileUtility.php for #6 
but the setError function still has a "string" type hint that throws a fatal error with PHP 5 (which we are forced to use unfortunately).

I removed the type hint in function call and added a type cast inside.  
Is this OK? Can you merge it?