### PR TITLE
[TASK] Streamline testsetup

### DIFF
--- a/Tests/Functional/Utility/FileUtilityTest.php
+++ b/Tests/Functional/Utility/FileUtilityTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Cobweb\Svconnector\Tests\Utility;
+namespace Cobweb\Svconnector\Tests\Functional\Utility;
 
 /*
  * This file is part of the TYPO3 CMS project.

--- a/Tests/Functional/Utility/FileUtilityTest.php
+++ b/Tests/Functional/Utility/FileUtilityTest.php
@@ -36,6 +36,7 @@ class FileUtilityTest extends FunctionalTestCase
 
     public function setUp(): void
     {
+        parent::setUp();
         try {
             //            $this->setUpBackendUserFromFixture(1);
             $this->subject = GeneralUtility::makeInstance(FileUtility::class);

--- a/Tests/Unit/Domain/Model/Dto/CallContextTest.php
+++ b/Tests/Unit/Domain/Model/Dto/CallContextTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * The TYPO3 project - inspiring people to share!
  */
 
-namespace Cobweb\Svconnector\Tests\Domain\Model\Dto;
+namespace Cobweb\Svconnector\Tests\Unit\Domain\Model\Dto;
 
 use Cobweb\Svconnector\Domain\Model\Dto\CallContext;
 use Cobweb\Svconnector\Exception\NoSuchContextException;

--- a/Tests/Unit/Utility/ConnectorUtilityTest.php
+++ b/Tests/Unit/Utility/ConnectorUtilityTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * The TYPO3 project - inspiring people to share!
  */
 
-namespace Cobweb\Svconnector\Tests\Utility;
+namespace Cobweb\Svconnector\Tests\Unit\Utility;
 
 use Cobweb\Svconnector\Exception\EmptySourceException;
 use Cobweb\Svconnector\Exception\InvalidSourceException;


### PR DESCRIPTION
- **[TASK] Ensure calling `parent::setUp()` in function test**
  This change modifies the existing functional test and
  adds the `parent::setUp()` method call to ensure a
  working functional test instance.
  

- **[TASK] Use test namespaces matching folder structure**
  This change modifies the unit and functional tests
  to reflect the test folder structure within the php
  namespaces.
  